### PR TITLE
Move root-path -> pipelines-root-path and make it required

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       
       - uses: grafana/fleet-management-sync-action@v1  # Replace with actual version/digest
         with:
-          root-path: 'pipelines'
+          pipelines-root-path: './pipelines'
           fm-username: ${{ secrets.FM_USERNAME }}
           fm-token: ${{ secrets.FM_TOKEN }}
 ```
@@ -34,7 +34,7 @@ jobs:
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `root-path` | Root path to start searching for pipeline YAML files | No | `.` |
+| `pipelines-root-path` | Root path to start searching for pipeline YAML files | Yes | - |
 | `fm-username` | Fleet Management username for authentication | Yes | - |
 | `fm-token` | Fleet Management API token for authentication | Yes | - |
 
@@ -75,7 +75,7 @@ The `contents_file` path is resolved in the following order:
 
 1. Absolute path - used as-is
 2. Relative to the YAML file's directory
-3. Relative to the `root-path`
+3. Relative to the `pipelines-root-path`
 
 ## Examples
 

--- a/action.yaml
+++ b/action.yaml
@@ -3,10 +3,9 @@ description: 'Sync pipeline configurations to Grafana Fleet Management'
 author: 'Grafana Labs'
 
 inputs:
-  root-path:
+  pipelines-root-path:
     description: 'Root path to start searching for pipeline YAML files'
-    required: false
-    default: '.'
+    required: true
   fm-username:
     description: 'Fleet Management username for authentication'
     required: true

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	cfg.SetupLogging()
 	slog.Info("Starting fm-sync",
-		"root_path", cfg.RootPath,
+		"pipelines_root_path", cfg.PipelinesRootPath,
 		"timeout", cfg.Timeout.String())
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,8 +10,9 @@ import (
 
 // Validation errors
 var (
-	ErrMissingUsername = errors.New("username must be provided")
-	ErrMissingToken    = errors.New("token must be provided")
+	ErrMissingUsername          = errors.New("username must be provided")
+	ErrMissingToken             = errors.New("token must be provided")
+	ErrMissingPipelinesRootPath = errors.New("pipelines root path must be provided")
 )
 
 // Default timeout for the action
@@ -19,8 +20,8 @@ const DefaultTimeout = 1 * time.Minute
 
 // Config is the inputs used to configure the action
 type Config struct {
-	// RootPath is the path to start recursing from when looking for pipelines
-	RootPath string
+	// PipelinesRootPath is the path to start recursing from when looking for pipelines
+	PipelinesRootPath string
 
 	// Username is the username when authenticating to Fleet Management
 	Username string
@@ -41,10 +42,10 @@ type Config struct {
 // NewFromEnv creates a new Config from GitHub Action environment variables
 func NewFromEnv() (*Config, error) {
 	cfg := &Config{
-		RootPath: os.Getenv("INPUT_ROOT_PATH"),
-		Username: os.Getenv("INPUT_FM_USERNAME"),
-		Token:    os.Getenv("INPUT_FM_TOKEN"),
-		Timeout:  DefaultTimeout,
+		PipelinesRootPath: os.Getenv("INPUT_ROOT_PATH"),
+		Username:          os.Getenv("INPUT_FM_USERNAME"),
+		Token:             os.Getenv("INPUT_FM_TOKEN"),
+		Timeout:           DefaultTimeout,
 	}
 
 	// Parse timeout if provided
@@ -80,6 +81,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Token == "" {
 		return ErrMissingToken
+	}
+	if c.PipelinesRootPath == "" {
+		return ErrMissingPipelinesRootPath
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,48 +9,48 @@ import (
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		cfg  Config
+		cfg     Config
 		wantErr error
 	}{
 		{
 			name: "valid inputs",
 			cfg: Config{
-				RootPath: "/some/path",
-				Username: "testuser",
-				Token:    "testtoken",
+				PipelinesRootPath: "/some/path",
+				Username:          "testuser",
+				Token:             "testtoken",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "missing username",
 			cfg: Config{
-				RootPath: "/some/path",
-				Token:    "testtoken",
+				PipelinesRootPath: "/some/path",
+				Token:             "testtoken",
 			},
 			wantErr: ErrMissingUsername,
 		},
 		{
 			name: "missing token",
 			cfg: Config{
-				RootPath: "/some/path",
-				Username: "testuser",
+				PipelinesRootPath: "/some/path",
+				Username:          "testuser",
 			},
 			wantErr: ErrMissingToken,
 		},
 		{
 			name: "missing both username and token",
 			cfg: Config{
-				RootPath: "/some/path",
+				PipelinesRootPath: "/some/path",
 			},
 			wantErr: ErrMissingUsername,
 		},
 		{
-			name: "empty root path is valid",
+			name: "empty pipelines root path is invalid",
 			cfg: Config{
 				Username: "testuser",
 				Token:    "testtoken",
 			},
-			wantErr: nil,
+			wantErr: ErrMissingPipelinesRootPath,
 		},
 	}
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -18,7 +18,7 @@ import (
 //
 // It returns a slice of all discovered pipelines, or an error if the discovery process fails.
 func FindPipelines(ctx context.Context, cfg *config.Config) ([]*pipeline.Pipeline, error) {
-	rootPath := cfg.RootPath
+	rootPath := cfg.PipelinesRootPath
 	if rootPath == "" {
 		cwd, err := os.Getwd()
 		if err != nil {

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -39,9 +39,9 @@ func TestDiscoverPipelines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input := &config.Config{
-				RootPath: tt.rootPath,
-				Username: "test",
-				Token:    "test",
+				PipelinesRootPath: tt.rootPath,
+				Username:          "test",
+				Token:             "test",
 			}
 
 			pipelines, err := FindPipelines(context.Background(), input)


### PR DESCRIPTION
Rather than specifying a generic `root-path`, this adds a `pipelines-root-path` that is required.

Related: https://github.com/grafana/fleet-management-sync-action/issues/2